### PR TITLE
Preprocessor support

### DIFF
--- a/lib/components/services/cards/index.js
+++ b/lib/components/services/cards/index.js
@@ -9,7 +9,7 @@ class CardsService {
    */
   boot (options) {
     this.cardTemplates = options.blueprintComponents.cardTemplates
-    this.cardPreprocessors = options.blueprintComponents.cardPreprocessors
+    this.cardPreprocessors = options.blueprintComponents.cardPreprocessors || { }
   } // boot
 
   get cards () {

--- a/lib/components/services/cards/index.js
+++ b/lib/components/services/cards/index.js
@@ -9,21 +9,54 @@ class CardsService {
    */
   boot (options) {
     this.cardTemplates = options.blueprintComponents.cardTemplates
-  }
+    this.cardPreprocessors = options.blueprintComponents.cardPreprocessors
+  } // boot
 
   get cards () {
-    const cards = {}
+    if (!this.cards_) {
+      this.cards_ = processCards(
+        this.cardTemplates,
+        this.cardPreprocessors
+      )
+    }
+    return this.cards_
+  } // cards
+} // class CardsService
 
-    for (const cardId of Object.keys(this.cardTemplates)) {
-      cards[cardId] = {
-        ...this.cardTemplates[cardId],
-        shasum: shasum(this.cardTemplates[cardId])
-      }
+function processCards (cardTemplates, cardPreprocessors) {
+  const cards = {}
+
+  const preprocessors = prepPreprocessors(cardPreprocessors)
+
+  for (const [cardId, cardTemplate] of Object.entries(cardTemplates)) {
+    if (preprocessors[cardId]) {
+      preprocessors[cardId](cardTemplate)
     }
 
-    return cards
+    cards[cardId] = {
+      ...cardTemplate,
+      shasum: shasum(cardTemplate)
+    }
   }
-}
+
+  return cards
+} // processCards
+
+function prepPreprocessors (cardPreprocessors) {
+  const processors = { }
+
+  for (const cp of Object.values(cardPreprocessors)) {
+    const appliesTo = Array.isArray(cp.appliesTo)
+      ? cp.appliesTo
+      : [cp.appliesTo]
+
+    for (const name of appliesTo) {
+      processors[name] = cp.function
+    }
+  }
+
+  return processors
+} // prepPreprocessors
 
 module.exports = {
   serviceClass: CardsService,


### PR DESCRIPTION
Blueprints can define a preprocessor functions, which are applied to named card templates. This allows, for example, boilerplate fields to be generated instead of hand-hacking, and with a flexibility not available during tymlyRef expansion.

Preprocessors are live in a blueprint's `card-preprocessors` directory. Preprocessors should be javascript files which export the preprocessor function, and the names of the card-templates to which it should be applied, eg
```
module.exports = {
  appliesTo: ['dm_propertyEditor_1_0', 'dm_streetEditor_1_0'],
  function: expandConflictMarkers
}
```
The function should take a single parameter, which will be the card-template JSON. It should operate on the JSON in place. Any return value is ignored.